### PR TITLE
Add gating tests of K8s integration

### DIFF
--- a/src/tests/bundles/bionic-train-k8s.yaml
+++ b/src/tests/bundles/bionic-train-k8s.yaml
@@ -1,0 +1,79 @@
+series: bionic
+applications:
+  ceph-fs:
+    charm: ceph-fs
+    series: bionic
+    num_units: 1
+    options:
+      source: cloud:bionic-train
+  ceph-osd:
+    charm: ceph-osd
+    num_units: 3
+    series: bionic
+    storage:
+      osd-devices: '10G'
+    options:
+      osd-devices: '/dev/test-non-existent'
+      source: cloud:bionic-train
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      monitor-count: '3'
+      source: cloud:bionic-train
+  kubernetes-master:
+    charm: cs:~containers/kubernetes-master
+    constraints: cores=2 mem=4G root-disk=16G
+    expose: true
+    num_units: 1
+  kubernetes-worker:
+    charm: cs:~containers/kubernetes-worker
+    constraints: cores=4 mem=4G root-disk=16G
+    num_units: 1
+  containerd:
+    charm: cs:~containers/containerd
+  flannel:
+    charm: cs:~containers/flannel
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+    to:
+    - lxd:kubernetes-master/0
+  etcd:
+    charm: cs:~containers/etcd
+    num_units: 1
+    options:
+      channel: 3.3/stable
+    to:
+    - kubernetes-master/0
+relations:
+- - ceph-mon:mds
+  - ceph-fs:ceph-mds
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-mon:admin
+  - kubernetes-master
+- - ceph-mon:client
+  - kubernetes-master
+- - kubernetes-master:kube-api-endpoint
+  - kubernetes-worker:kube-api-endpoint
+- - kubernetes-master:kube-control
+  - kubernetes-worker:kube-control
+- - kubernetes-master:certificates
+  - easyrsa:client
+- - kubernetes-master:etcd
+  - etcd:db
+- - kubernetes-worker:certificates
+  - easyrsa:client
+- - etcd:certificates
+  - easyrsa:client
+- - flannel:etcd
+  - etcd:db
+- - flannel:cni
+  - kubernetes-master:cni
+- - flannel:cni
+  - kubernetes-worker:cni
+- - containerd:containerd
+  - kubernetes-worker:container-runtime
+- - containerd:containerd
+  - kubernetes-master:container-runtime

--- a/src/tests/tests.yaml
+++ b/src/tests/tests.yaml
@@ -9,6 +9,7 @@ gate_bundles:
   # https://bugs.launchpad.net/charm-nova-compute/+bug/1862624
   - xenial-ocata
   - xenial-mitaka
+  - k8s: bionic-train-k8s
 smoke_bundles:
   - bionic-stein
 dev_bundles:
@@ -19,5 +20,27 @@ configure:
   - zaza.openstack.charm_tests.nova.setup.create_flavors
   - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
   - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+  - k8s: []
 tests:
   - zaza.openstack.charm_tests.ceph.fs.tests.CephFSTests
+  - k8s:
+    - zaza.openstack.charm_tests.ceph.tests.CephFSK8sTest
+target_deploy_status:
+  easyrsa:
+    workload-status: active
+    workload-status-message: "Certificate Authority connected."
+  etcd:
+    workload-status: active
+    workload-status-message: "Healthy"
+  kubernetes-master:
+    workload-status: active
+    workload-status-message: "Kubernetes master running."
+  kubernetes-worker:
+    workload-status: active
+    workload-status-message: "Kubernetes worker running."
+  containerd:
+    workload-status: active
+    workload-status-message: "Container runtime available"
+  flannel:
+    workload-status: active
+    workload-status-message: "Flannel subnet"


### PR DESCRIPTION
This is a draft PR just for linking and discussion purposes. When this is actually ready, this PR should be closed and a proper Gerrit review created.

I haven't been able to get this to work, since the `k8s` bundle alias insists on picking up the configure step for the unnamed bundle but since Glance isn't included, it fails.  (Same issue in johnsca/charm-ceph-mon#1)

This depends on the new tests in openstack-charmers/zaza-openstack-tests#205